### PR TITLE
Update Styling of LogInForm and CheckInForm, Update Text for Nav Buttons

### DIFF
--- a/src/BasicInfoForm/BasicInfoForm.css
+++ b/src/BasicInfoForm/BasicInfoForm.css
@@ -1,15 +1,15 @@
 .BasicInfoForm {
   width: 100%;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   margin-top: 20px;
-  display: inline-block;
 }
 
 #basic-info-header {
-  text-align: center;
   font-size: 30px;
+  width: 75%;
 }
 
 #fullname-container,

--- a/src/BasicInfoForm/BasicInfoForm.css
+++ b/src/BasicInfoForm/BasicInfoForm.css
@@ -33,7 +33,7 @@
 }
 
 #fullname-label, #age-label, #phone-label {
-width: 35%;
+width: 45%;
 text-align: end;
 font-size: 20px;
 }

--- a/src/CheckInForm/CheckInForm.css
+++ b/src/CheckInForm/CheckInForm.css
@@ -14,3 +14,34 @@
   overflow-y: scroll;
 }
 
+hr {
+  width: 100%;
+  border: 1px solid white;
+}
+
+#submit-form-button-container {
+  height: 200px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+#submit-form-text {
+  width: 60%;
+  font-size: 15px;
+  text-align: center;
+}
+
+#submit-form-button {
+  margin-top: 15px;
+  margin-bottom: 50px;
+  width: 50%;
+  height: 50px;
+  font-size: 30px;
+  align-self: center;
+  border-radius: 5px;
+  background-color: #782a30;
+  color: white;
+}
+

--- a/src/CheckInForm/CheckInForm.css
+++ b/src/CheckInForm/CheckInForm.css
@@ -13,3 +13,4 @@
   font-weight: bold;
   overflow-y: scroll;
 }
+

--- a/src/CheckInForm/CheckInForm.js
+++ b/src/CheckInForm/CheckInForm.js
@@ -2,14 +2,18 @@ import React, { useState } from "react";
 import BasicInfoForm from "../BasicInfoForm/BasicInfoForm";
 import NeedsForm from "../NeedsForm/NeedsForm";
 import EmergencyContactForm from "../EmergencyContactForm/EmergencyContactForm";
-import { postNewUser, postNeeds, postEmergencyContacts } from "../apiCalls/apiCalls";
+import {
+  postNewUser,
+  postNeeds,
+  postEmergencyContacts
+} from "../apiCalls/apiCalls";
 import "./CheckInForm.css";
 
 const CheckInForm = ({ reliefCenter }) => {
   const [personName, setPersonName] = useState("");
   const [personAge, setPersonAge] = useState("");
   const [personPhone, setPersonPhone] = useState("");
-  const [neededItems, setNeededItems] = useState([])
+  const [neededItems, setNeededItems] = useState([]);
   const [items, setItems] = useState([
     "Diapers",
     "Baby Wipes",
@@ -24,7 +28,7 @@ const CheckInForm = ({ reliefCenter }) => {
   const [emergencyName, setEmergencyName] = useState("");
   const [emergencyPhone, setEmergencyPhone] = useState("");
   const [emergencyRelationship, setEmergencyRelationship] = useState("");
-  const [sendMessage, setSendMessage] = useState(false)
+  const [sendMessage, setSendMessage] = useState(false);
 
   const submitUser = async e => {
     e.preventDefault();
@@ -40,8 +44,8 @@ const CheckInForm = ({ reliefCenter }) => {
     };
     let userId = await postNewUser(personData, reliefCenter);
 
-    await postNeeds(userId, neededItems)
-    await postEmergencyContacts(userId, personData)
+    await postNeeds(userId, neededItems);
+    await postEmergencyContacts(userId, personData);
   };
 
   return (
@@ -54,7 +58,12 @@ const CheckInForm = ({ reliefCenter }) => {
         personPhone={personPhone}
         setPersonPhone={setPersonPhone}
       />
-      <NeedsForm items={items} setItems={setItems} neededItems={neededItems} setNeededItems={setNeededItems} />
+      <NeedsForm
+        items={items}
+        setItems={setItems}
+        neededItems={neededItems}
+        setNeededItems={setNeededItems}
+      />
       <EmergencyContactForm
         emergencyName={emergencyName}
         setEmergencyName={setEmergencyName}
@@ -65,7 +74,17 @@ const CheckInForm = ({ reliefCenter }) => {
         sendMessage={sendMessage}
         setSendMessage={setSendMessage}
       />
-        <button id="submit" onClick={submitUser}>Submit</button>
+      <hr />
+      <div id="submit-form-button-container">
+        <h3 id="submit-form-text">
+          By clicking the "Submit Form" button below, I certify that all
+          information in this form is true and correct to the best of my
+          knowledge.
+        </h3>
+        <button id="submit-form-button" onClick={submitUser}>
+          Submit Form
+        </button>
+      </div>
     </section>
   );
 };

--- a/src/CheckInForm/CheckInForm.js
+++ b/src/CheckInForm/CheckInForm.js
@@ -11,13 +11,13 @@ const CheckInForm = ({ reliefCenter }) => {
   const [personPhone, setPersonPhone] = useState("");
   const [neededItems, setNeededItems] = useState([])
   const [items, setItems] = useState([
-    "diapers",
-    "baby wipes",
-    "breastfeeding supplies",
-    "infant formula",
-    "feminine products",
-    "phone charger (iphone)",
-    "phone charger (android)",
+    "Diapers",
+    "Baby Wipes",
+    "Breastfeeding Supplies",
+    "Infant Formula",
+    "Feminine Products",
+    "Phone Charger (iphone)",
+    "Phone Charger (android)",
     "add item"
   ]);
 

--- a/src/EmergencyContactForm/EmergencyContactForm.css
+++ b/src/EmergencyContactForm/EmergencyContactForm.css
@@ -34,4 +34,28 @@
   width: 35%;
   text-align: end;
   font-size: 20px;
-  }
+}
+
+#make-public-or-private-container {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+#public-or-private-button-text {
+  width: 60%;
+  font-size: 15px;
+  text-align: center;
+}
+
+#make-public-or-private-button {
+  width: 25%;
+  height: 45px;
+  font-size: 20px;
+  background-color: #782a30;
+  color: white;
+  border-radius: 5px;
+}

--- a/src/EmergencyContactForm/EmergencyContactForm.css
+++ b/src/EmergencyContactForm/EmergencyContactForm.css
@@ -31,7 +31,7 @@
 }
 
 #relationship-label {
-  width: 35%;
+  width: 45%;
   text-align: end;
   font-size: 20px;
 }
@@ -52,7 +52,7 @@
 }
 
 #make-public-or-private-button {
-  width: 25%;
+  width: 30%;
   height: 45px;
   font-size: 20px;
   background-color: #782a30;

--- a/src/EmergencyContactForm/EmergencyContactForm.css
+++ b/src/EmergencyContactForm/EmergencyContactForm.css
@@ -3,13 +3,13 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  flex-direction: column;
   margin-top: 20px;
-  display: inline-block;
 }
 
 #emergency-contact-info-header {
-  text-align: center;
   font-size: 30px;
+  width: 75%;
 }
 
 #field {

--- a/src/EmergencyContactForm/EmergencyContactForm.js
+++ b/src/EmergencyContactForm/EmergencyContactForm.js
@@ -57,7 +57,7 @@ const EmergencyContactForm = ({
           type="text"
           name="relationship"
           value={emergencyRelationship}
-          placeholder="Add relationship"
+          placeholder="Add Relationship"
           onChange={e => setEmergencyRelationship(e.target.value)}
         />
       </div>

--- a/src/EmergencyContactForm/EmergencyContactForm.js
+++ b/src/EmergencyContactForm/EmergencyContactForm.js
@@ -1,36 +1,77 @@
-import React from 'react'
-import './EmergencyContactForm.css'
+import React from "react";
+import "./EmergencyContactForm.css";
 
-const EmergencyContactForm = ({emergencyName, setEmergencyName, emergencyPhone, setEmergencyPhone, emergencyRelationship, setEmergencyRelationship, sendMessage, setSendMessage}) => {
-
-  const toggleSendMessage = (e) => {
-    e.preventDefault()
-    setSendMessage(!sendMessage)
-  }
+const EmergencyContactForm = ({
+  emergencyName,
+  setEmergencyName,
+  emergencyPhone,
+  setEmergencyPhone,
+  emergencyRelationship,
+  setEmergencyRelationship,
+  sendMessage,
+  setSendMessage
+}) => {
+  const toggleSendMessage = e => {
+    e.preventDefault();
+    setSendMessage(!sendMessage);
+  };
 
   return (
     <form className="EmergencyContactForm">
       <h1 id="emergency-contact-info-header">Emergency Contact Information:</h1>
 
-      <div id='field'> 
-       <label id="fullname-label" for="Full Name">Full Name:</label>
-       <input id="fullname" type="text" name='name' value={emergencyName} placeholder="Add Full Name" onChange={e => setEmergencyName(e.target.value)}/>
+      <div id="field">
+        <label id="fullname-label" for="Full Name">
+          Full Name:
+        </label>
+        <input
+          id="fullname"
+          type="text"
+          name="name"
+          value={emergencyName}
+          placeholder="Add Full Name"
+          onChange={e => setEmergencyName(e.target.value)}
+        />
       </div>
 
-      <div id='field'> 
-        <label id="phone-label" for="phone">Phone:</label>
-        <input id="phone" type='text' name='phone' value={emergencyPhone} placeholder="Add Phone Number" onChange={e => setEmergencyPhone(e.target.value)}/>
+      <div id="field">
+        <label id="phone-label" for="phone">
+          Phone:
+        </label>
+        <input
+          id="phone"
+          type="text"
+          name="phone"
+          value={emergencyPhone}
+          placeholder="Add Phone Number"
+          onChange={e => setEmergencyPhone(e.target.value)}
+        />
       </div>
 
-      <div id='field'> 
-       <label id="relationship-label" for="relationship">Relationship:</label>
-       <input id="relationship" type='text' name='relationship' value={emergencyRelationship} placeholder="Add relationship" onChange={e => setEmergencyRelationship(e.target.value)}/> 
+      <div id="field">
+        <label id="relationship-label" for="relationship">
+          Relationship:
+        </label>
+        <input
+          id="relationship"
+          type="text"
+          name="relationship"
+          value={emergencyRelationship}
+          placeholder="Add relationship"
+          onChange={e => setEmergencyRelationship(e.target.value)}
+        />
       </div>
 
-      <button onClick={e => toggleSendMessage(e)}>Click Me to Allow Text to Contact</button>
+      <div id="make-public-or-private-container">
+        <h3 id="public-or-private-button-text">
+          By clicking the following button, I agree to allow a message to be sent to the emergency contact number listed above.
+        </h3>
+        <button id="make-public-or-private-button" onClick={e => toggleSendMessage(e)}>
+          Send Text to Contact
+        </button>
+      </div>
     </form>
-  )
-}
+  );
+};
 
 export default EmergencyContactForm;
-

--- a/src/Item/Item.css
+++ b/src/Item/Item.css
@@ -19,9 +19,9 @@
 #new-item {
   font-size: 20px;
   padding-left: 5px;
-  width: 84%;
+  width: 40%;
   height: 50px;
-  border-radius: 5px;
+  border-radius: 5px 0px 0px 5px;
 }
 
 #item-name:hover {
@@ -35,9 +35,20 @@
   justify-content: center;
   align-items: center;
 }
-/* #dietary-item,
-#medications-item,
-#allergies-item,
-#other-item {
-  margin-left: 9%;
-} */
+
+#add-item-container {
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+
+#submit-new-item {
+  background-color: #6C782A;
+  width: 10%;
+  height: 50px;
+  /* border-radius: 5px; */
+}
+ #plus-img {
+   height: 30px;
+ }

--- a/src/Item/Item.js
+++ b/src/Item/Item.js
@@ -1,42 +1,48 @@
 import React, { useState } from "react";
 import "./Item.css";
 
-const Item = ({ item, items, setItems, neededItems, setNeededItems}) => {
-  const [newItem, setNewItem] = useState("")
+const Item = ({ item, items, setItems, neededItems, setNeededItems }) => {
+  const [newItem, setNewItem] = useState("");
 
   const handleChange = e => setNewItem(e.target.value);
 
   const handleSubmit = (e, newItem) => {
     e.preventDefault();
-    items.splice(items.length - 1, 0, newItem)
-    setItems([...items])
-    setNeededItems([...neededItems, newItem])
-  }
+    items.splice(items.length - 1, 0, newItem);
+    setItems([...items]);
+    setNeededItems([...neededItems, newItem]);
+  };
 
-  const handleCheck = (e) => {
+  const handleCheck = e => {
     if (!neededItems.includes(item)) {
       setNeededItems([...neededItems, item]);
     } else {
       let filteredItems = neededItems.filter(itemName => itemName !== item);
-      setNeededItems(filteredItems)
+      setNeededItems(filteredItems);
     }
-  }
-  
+  };
+
   return (
     <article className="Item">
-      {item === "add item" ?
-        <div id="add-item-container"> 
-          <input 
-          id="new-item" 
-          type="text" 
-          placeholder="Add Item/Medication" 
-          name="name" 
-          value={newItem} 
-          onChange={handleChange} 
-          />        
-          <button type="submit" onClick={e => handleSubmit(e, newItem)}>+++</button>
-        </div> 
-      : 
+      {item === "add item" ? (
+        <div id="add-item-container">
+          <input
+            id="new-item"
+            type="text"
+            placeholder="Add Item/Medication"
+            name="name"
+            value={newItem}
+            onChange={handleChange}
+          />
+          <button id="submit-new-item" type="submit" onClick={e => handleSubmit(e, newItem)}>
+            <img
+              id="plus-img"
+              alt="plus symbol"
+              src={require("../assets/plus-sign.svg")}
+            />
+          </button>
+        </div>
+      ) : (
         <div id="checkbox-item-container">
           <img
             id="check-or-uncheck"
@@ -48,9 +54,11 @@ const Item = ({ item, items, setItems, neededItems, setNeededItems}) => {
             }
             onClick={handleCheck}
           />
-          <h3 id="item-name" onClick={handleCheck}>{item}</h3>
+          <h3 id="item-name" onClick={handleCheck}>
+            {item}
+          </h3>
         </div>
-      }
+      )}
     </article>
   );
 };

--- a/src/LogInForm/LogInForm.css
+++ b/src/LogInForm/LogInForm.css
@@ -8,7 +8,14 @@
   display: flex;
   width: 80%;
   justify-content: center;
+  flex-direction: column;
   align-items: center;
+}
+
+#login-form-instructions {
+  color: white;
+  text-align: center;
+  font-size: 30px;
 }
 
 .navigation-menu {

--- a/src/LogInForm/LogInForm.js
+++ b/src/LogInForm/LogInForm.js
@@ -1,38 +1,51 @@
 import React, { useContext } from "react";
 import Map from "../Map/Map";
 import { NavLink } from "react-router-dom";
-import { getItems } from '../apiCalls/apiCalls';
-import { ItemsContext } from '../Contexts/ItemsContext';
+import { getItems } from "../apiCalls/apiCalls";
+import { ItemsContext } from "../Contexts/ItemsContext";
 import "./LogInForm.css";
 
 const LogInForm = ({ reliefCenter, selectCenter, isCenterSelected }) => {
   const { currentItems, setCurrentItems } = useContext(ItemsContext);
 
   const fetchItems = async () => {
-    let items = await getItems(reliefCenter)
-    setCurrentItems(items)
-  }
+    let items = await getItems(reliefCenter);
+    setCurrentItems(items);
+  };
 
   return (
     <section className="LogInForm">
-    {!isCenterSelected ? 
-      <article className="pick-relief-center-menu">
-        <Map selectCenter={selectCenter}/>
-      </article> 
-    : 
-    <article className="navigation-menu">
-        <button className="LogInForm_button-back" onClick={() => selectCenter(false)}>Back to Home</button>
-      <NavLink to="/supplies" className="Link" id="supplies-button" onClick={fetchItems}>
-        <button id="supplies-button">Supplies</button>
-      </NavLink>
-      <NavLink to="/check-in" className="Link" id="check-in-button">
-        <button id="check-in-button">Check In</button>
-      </NavLink>
-      <NavLink to="/check-out" className="Link" id="check-out-button">
+      {!isCenterSelected ? (
+        <article className="pick-relief-center-menu">
+          <h2 id="login-form-instructions">
+            Please select the location of the relief center for which you are currently stationed.
+          </h2>
+          <Map selectCenter={selectCenter} />
+        </article>
+      ) : (
+        <article className="navigation-menu">
+          <button
+            className="LogInForm_button-back"
+            onClick={() => selectCenter(false)}
+          >
+            Back to Home
+          </button>
+          <NavLink
+            to="/supplies"
+            className="Link"
+            id="supplies-button"
+            onClick={fetchItems}
+          >
+            <button id="supplies-button">Supplies</button>
+          </NavLink>
+          <NavLink to="/check-in" className="Link" id="check-in-button">
+            <button id="check-in-button">Check In</button>
+          </NavLink>
+          <NavLink to="/check-out" className="Link" id="check-out-button">
             <button id="check-out-button">Check Out</button>
-      </NavLink>
-    </article>
-    }
+          </NavLink>
+        </article>
+      )}
     </section>
   );
 };

--- a/src/LogInForm/LogInForm.js
+++ b/src/LogInForm/LogInForm.js
@@ -39,10 +39,10 @@ const LogInForm = ({ reliefCenter, selectCenter, isCenterSelected }) => {
             <button id="supplies-button">Supplies</button>
           </NavLink>
           <NavLink to="/check-in" className="Link" id="check-in-button">
-            <button id="check-in-button">Check In</button>
+            <button id="check-in-button">Check-In Displaced Person</button>
           </NavLink>
           <NavLink to="/check-out" className="Link" id="check-out-button">
-            <button id="check-out-button">Check Out</button>
+            <button id="check-out-button">Check-Out Displaced Person</button>
           </NavLink>
         </article>
       )}

--- a/src/Map/Map.css
+++ b/src/Map/Map.css
@@ -1,4 +1,4 @@
 .Map_container {
   height: 60vh;
-  width: 100%;
+  width: 70%;
 }

--- a/src/NeedsForm/NeedsForm.css
+++ b/src/NeedsForm/NeedsForm.css
@@ -1,9 +1,17 @@
+.NeedsForm {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
 .items-container {
   overflow-y: scroll;
 }
 
 #necessities-header, #medications-header {
-  text-align: center;
   font-size: 30px;
-  margin: 15px;
+  width: 75%;
+  margin-bottom: 10px;
 }

--- a/src/assets/plus-sign.svg
+++ b/src/assets/plus-sign.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Capa_1" x="0px" y="0px" viewBox="0 0 42 42" style="enable-background:new 0 0 42 42;" xml:space="preserve" width="512px" height="512px" class=""><g><polygon points="42,19 23,19 23,0 19,0 19,19 0,19 0,23 19,23 19,42 23,42 23,23 42,23 " data-original="#000000" class="active-path" data-old_color="#000000" fill="#FFFFFF"/><script xmlns="" class="active-path" style=""/></g> </svg>


### PR DESCRIPTION
#### What’s this PR do?
This PR updates the styling of LogInForm and CheckInForm, and also updates the text for the Nav buttons.
#### Where should the reviewer start?
The reviewer should start by entering <localhost:3000> into the app, selecting a relief center, and clicking on the "Check-In Displaced Person" button.
#### How should this be manually tested?
See above, and also review each page for the stylistic and text updates, which were made on the basis of clarity, user-friendliness, and general polish.
#### Any background context you want to provide?
I asked my partner to try and use our app, and gave her some light context. I noted that she was confused about what to do at the login page, and then proceeded to use the CheckInForm to account for herself as a perspective "relief worker". This indicated that some updates needed to be made to clarify how the app is intended to be used, and by whom.
#### What are the relevant tickets?
Issue #53: As a relief center worker, when I log in, I am instructed to select a center on the map
Issue #54: Add specificity to Check In and Check Out buttons
Issue #56: Add styling to CheckInForm Add Item input
Issue #58: Add styling to CheckInForm buttons ("Click to Allow Text to Contact" && "Submit") 
#### Screenshots (if appropriate)

Log In Screen
![Screen Shot 2019-10-29 at 5 27 03 PM](https://user-images.githubusercontent.com/11339301/67816973-5b359f00-fa71-11e9-80c2-0dbd5ae68c07.png)

Nav Buttons
![Screen Shot 2019-10-29 at 5 28 29 PM](https://user-images.githubusercontent.com/11339301/67817017-8b7d3d80-fa71-11e9-9e3a-c391777ca976.png)

Check In Form (pt 1)
![Screen Shot 2019-10-29 at 5 12 02 PM](https://user-images.githubusercontent.com/11339301/67816940-36d9c280-fa71-11e9-8c01-9aea49f15d19.png)

Check In Form (pt 2)
![Screen Shot 2019-10-29 at 5 11 01 PM](https://user-images.githubusercontent.com/11339301/67816943-3b05e000-fa71-11e9-93f9-4850032fd9dd.png)
