### PR TITLE
Initialize snapshot tests in components

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "apollo-boost": "^0.4.4",
     "google-map-react": "^1.1.5",
     "graphql": "^14.5.8",
+    "prop-types": "^15.7.2",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
     "react-router-dom": "^5.1.2",
@@ -54,6 +55,11 @@
   "jest": {
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
+    ],
+    "collectCoverageFrom": [
+      "src/**/*.{js,jsx}",
+      "!src/index.js",
+      "!src/serviceWorker.js"
     ]
   }
 }

--- a/src/App/__snapshots__/App.test.js.snap
+++ b/src/App/__snapshots__/App.test.js.snap
@@ -18,7 +18,7 @@ exports[`App should match the snapshot with the data passed through 1`] = `
         "entries": Array [
           Object {
             "hash": "",
-            "key": "b1kxmx",
+            "key": "0huotd",
             "pathname": "/",
             "search": "",
             "state": undefined,
@@ -32,7 +32,7 @@ exports[`App should match the snapshot with the data passed through 1`] = `
         "listen": [Function],
         "location": Object {
           "hash": "",
-          "key": "b1kxmx",
+          "key": "0huotd",
           "pathname": "/",
           "search": "",
           "state": undefined,
@@ -5325,6 +5325,11 @@ exports[`App should match the snapshot with the data passed through 1`] = `
                 <article
                   className="pick-relief-center-menu"
                 >
+                  <h2
+                    id="login-form-instructions"
+                  >
+                    Please select the location of the relief center for which you are currently stationed.
+                  </h2>
                   <Map
                     selectCenter={[Function]}
                   >

--- a/src/BasicInfoForm/BasicInfoForm.js
+++ b/src/BasicInfoForm/BasicInfoForm.js
@@ -8,11 +8,11 @@ const BasicInfoForm = ({personName, setPersonName, personAge, setPersonAge, pers
       <h1 id="basic-info-header">Basic Information:</h1>
       <div id="fullname-container">
         <label id="fullname-label" htmlFor="fullname">Full Name:</label>
-        <input id="fullname" type="text" placeholder="Add Full Name" onChange={e => setPersonName(e.target.value)} name="name" value={personName}/>
+        <input id="fullname" type="text" placeholder="Add Full Name" onChange={e => setPersonName(e.target.value)} name="name" value={personName} />
       </div>
       <div id="age-container">
         <label id="age-label" htmlFor="age">Age:</label>
-        <input id="age" type='text' placeholder="Add Age" onChange={e => setPersonAge(e.target.value)} name="age" value={personAge}/>
+        <input id="age" type='text' placeholder="Add Age" onChange={e => setPersonAge(e.target.value)} name="age" value={personAge} />
       </div>
       <div id="phone-container">
         <label id="phone-label" htmlFor="phone">Phone Number:</label>

--- a/src/BasicInfoForm/BasicInfoForm.test.js
+++ b/src/BasicInfoForm/BasicInfoForm.test.js
@@ -1,0 +1,32 @@
+import React from "react";
+import { shallow } from "enzyme";
+import BasicInfoForm from "./BasicInfoForm";
+import { configure } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+
+configure({ adapter: new Adapter() });
+
+describe("BasicInfoForm", () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(
+      <BasicInfoForm
+        personName=""
+        setPersonName={jest.fn()}
+        personAge=""
+        setPersonAge={jest.fn()}
+        personPhone=""
+        setPersonPhone={jest.fn()}
+      />
+    );
+  });
+
+  it("should render without crashing", () => {
+    expect(wrapper.length).toEqual(1);
+  });
+
+  it("should match the snapshot with three empty name, age, and phone inputs passed through", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/BasicInfoForm/__snapshots__/BasicInfoForm.test.js.snap
+++ b/src/BasicInfoForm/__snapshots__/BasicInfoForm.test.js.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BasicInfoForm should match the snapshot with three empty name, age, and phone inputs passed through 1`] = `
+<form
+  className="BasicInfoForm"
+>
+  <h1
+    id="basic-info-header"
+  >
+    Basic Information:
+  </h1>
+  <div
+    id="fullname-container"
+  >
+    <label
+      htmlFor="fullname"
+      id="fullname-label"
+    >
+      Full Name:
+    </label>
+    <input
+      id="fullname"
+      name="name"
+      onChange={[Function]}
+      placeholder="Add Full Name"
+      type="text"
+      value=""
+    />
+  </div>
+  <div
+    id="age-container"
+  >
+    <label
+      htmlFor="age"
+      id="age-label"
+    >
+      Age:
+    </label>
+    <input
+      id="age"
+      name="age"
+      onChange={[Function]}
+      placeholder="Add Age"
+      type="text"
+      value=""
+    />
+  </div>
+  <div
+    id="phone-container"
+  >
+    <label
+      htmlFor="phone"
+      id="phone-label"
+    >
+      Phone Number:
+    </label>
+    <input
+      id="phone"
+      name="phone"
+      onChange={[Function]}
+      placeholder="Add Phone Number"
+      type="text"
+      value=""
+    />
+  </div>
+</form>
+`;

--- a/src/CheckInForm/CheckInForm.js
+++ b/src/CheckInForm/CheckInForm.js
@@ -8,6 +8,7 @@ import { NavLink } from "react-router-dom";
 import "./CheckInForm.css";
 
 const CheckInForm = ({ reliefCenter }) => {
+  console.log(reliefCenter)
   const { currentUsers, setCurrentUsers } = useContext(UsersContext)
   const [isUserSubmitted, setSubmittedStatus] = useState(false)
   const [personName, setPersonName] = useState("");

--- a/src/CheckInForm/CheckInForm.test.js
+++ b/src/CheckInForm/CheckInForm.test.js
@@ -1,0 +1,35 @@
+import React from "react";
+import { mount } from "enzyme";
+import CheckInForm from "./CheckInForm";
+import { configure } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+
+configure({ adapter: new Adapter() });
+
+describe("CheckInForm", () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mount(
+      <CheckInForm
+      reliefCenter={{        
+        name: "Turing Relief Center",
+        addressPrint: "1331 17th St Denver CO 80202",
+        lat: "39.7508132",
+        lng: "-104.9967997",
+        phone: "5555555555",
+        website: "www.relief-center.com",
+        id: "1"
+      }}
+      />
+    );
+  });
+
+  it("should render without crashing", () => {
+    expect(wrapper.length).toEqual(1);
+  });
+
+  it("should match the snapshot", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/CheckInForm/__snapshots__/CheckInForm.test.js.snap
+++ b/src/CheckInForm/__snapshots__/CheckInForm.test.js.snap
@@ -1,0 +1,629 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CheckInForm should match the snapshot 1`] = `
+<CheckInForm
+  reliefCenter={
+    Object {
+      "addressPrint": "1331 17th St Denver CO 80202",
+      "id": "1",
+      "lat": "39.7508132",
+      "lng": "-104.9967997",
+      "name": "Turing Relief Center",
+      "phone": "5555555555",
+      "website": "www.relief-center.com",
+    }
+  }
+>
+  <section
+    className="CheckInForm"
+  >
+    <BasicInfoForm
+      personAge=""
+      personName=""
+      personPhone=""
+      setPersonAge={[Function]}
+      setPersonName={[Function]}
+      setPersonPhone={[Function]}
+    >
+      <form
+        className="BasicInfoForm"
+      >
+        <h1
+          id="basic-info-header"
+        >
+          Basic Information:
+        </h1>
+        <div
+          id="fullname-container"
+        >
+          <label
+            htmlFor="fullname"
+            id="fullname-label"
+          >
+            Full Name:
+          </label>
+          <input
+            id="fullname"
+            name="name"
+            onChange={[Function]}
+            placeholder="Add Full Name"
+            type="text"
+            value=""
+          />
+        </div>
+        <div
+          id="age-container"
+        >
+          <label
+            htmlFor="age"
+            id="age-label"
+          >
+            Age:
+          </label>
+          <input
+            id="age"
+            name="age"
+            onChange={[Function]}
+            placeholder="Add Age"
+            type="text"
+            value=""
+          />
+        </div>
+        <div
+          id="phone-container"
+        >
+          <label
+            htmlFor="phone"
+            id="phone-label"
+          >
+            Phone Number:
+          </label>
+          <input
+            id="phone"
+            name="phone"
+            onChange={[Function]}
+            placeholder="Add Phone Number"
+            type="text"
+            value=""
+          />
+        </div>
+      </form>
+    </BasicInfoForm>
+    <NeedsForm
+      items={
+        Array [
+          "Diapers",
+          "Baby Wipes",
+          "Breastfeeding Supplies",
+          "Infant Formula",
+          "Feminine Products",
+          "Phone Charger (iphone)",
+          "Phone Charger (android)",
+          "add item",
+        ]
+      }
+      neededItems={Array []}
+      setItems={[Function]}
+      setNeededItems={[Function]}
+    >
+      <section
+        className="NeedsForm"
+      >
+        <h1
+          id="necessities-header"
+        >
+          Necessities:
+        </h1>
+        <article
+          id="items-container"
+        >
+          <Item
+            item="Diapers"
+            items={
+              Array [
+                "Diapers",
+                "Baby Wipes",
+                "Breastfeeding Supplies",
+                "Infant Formula",
+                "Feminine Products",
+                "Phone Charger (iphone)",
+                "Phone Charger (android)",
+                "add item",
+              ]
+            }
+            key="0"
+            neededItems={Array []}
+            setItems={[Function]}
+            setNeededItems={[Function]}
+          >
+            <article
+              className="Item"
+            >
+              <div
+                id="checkbox-item-container"
+              >
+                <img
+                  alt=""
+                  id="check-or-uncheck"
+                  onClick={[Function]}
+                  src={
+                    Object {
+                      "ReactComponent": Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "render": [Function],
+                      },
+                      "__esModule": true,
+                      "default": "unchecked.svg",
+                    }
+                  }
+                />
+                <h3
+                  id="item-name"
+                  onClick={[Function]}
+                >
+                  Diapers
+                </h3>
+              </div>
+            </article>
+          </Item>
+          <Item
+            item="Baby Wipes"
+            items={
+              Array [
+                "Diapers",
+                "Baby Wipes",
+                "Breastfeeding Supplies",
+                "Infant Formula",
+                "Feminine Products",
+                "Phone Charger (iphone)",
+                "Phone Charger (android)",
+                "add item",
+              ]
+            }
+            key="1"
+            neededItems={Array []}
+            setItems={[Function]}
+            setNeededItems={[Function]}
+          >
+            <article
+              className="Item"
+            >
+              <div
+                id="checkbox-item-container"
+              >
+                <img
+                  alt=""
+                  id="check-or-uncheck"
+                  onClick={[Function]}
+                  src={
+                    Object {
+                      "ReactComponent": Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "render": [Function],
+                      },
+                      "__esModule": true,
+                      "default": "unchecked.svg",
+                    }
+                  }
+                />
+                <h3
+                  id="item-name"
+                  onClick={[Function]}
+                >
+                  Baby Wipes
+                </h3>
+              </div>
+            </article>
+          </Item>
+          <Item
+            item="Breastfeeding Supplies"
+            items={
+              Array [
+                "Diapers",
+                "Baby Wipes",
+                "Breastfeeding Supplies",
+                "Infant Formula",
+                "Feminine Products",
+                "Phone Charger (iphone)",
+                "Phone Charger (android)",
+                "add item",
+              ]
+            }
+            key="2"
+            neededItems={Array []}
+            setItems={[Function]}
+            setNeededItems={[Function]}
+          >
+            <article
+              className="Item"
+            >
+              <div
+                id="checkbox-item-container"
+              >
+                <img
+                  alt=""
+                  id="check-or-uncheck"
+                  onClick={[Function]}
+                  src={
+                    Object {
+                      "ReactComponent": Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "render": [Function],
+                      },
+                      "__esModule": true,
+                      "default": "unchecked.svg",
+                    }
+                  }
+                />
+                <h3
+                  id="item-name"
+                  onClick={[Function]}
+                >
+                  Breastfeeding Supplies
+                </h3>
+              </div>
+            </article>
+          </Item>
+          <Item
+            item="Infant Formula"
+            items={
+              Array [
+                "Diapers",
+                "Baby Wipes",
+                "Breastfeeding Supplies",
+                "Infant Formula",
+                "Feminine Products",
+                "Phone Charger (iphone)",
+                "Phone Charger (android)",
+                "add item",
+              ]
+            }
+            key="3"
+            neededItems={Array []}
+            setItems={[Function]}
+            setNeededItems={[Function]}
+          >
+            <article
+              className="Item"
+            >
+              <div
+                id="checkbox-item-container"
+              >
+                <img
+                  alt=""
+                  id="check-or-uncheck"
+                  onClick={[Function]}
+                  src={
+                    Object {
+                      "ReactComponent": Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "render": [Function],
+                      },
+                      "__esModule": true,
+                      "default": "unchecked.svg",
+                    }
+                  }
+                />
+                <h3
+                  id="item-name"
+                  onClick={[Function]}
+                >
+                  Infant Formula
+                </h3>
+              </div>
+            </article>
+          </Item>
+          <Item
+            item="Feminine Products"
+            items={
+              Array [
+                "Diapers",
+                "Baby Wipes",
+                "Breastfeeding Supplies",
+                "Infant Formula",
+                "Feminine Products",
+                "Phone Charger (iphone)",
+                "Phone Charger (android)",
+                "add item",
+              ]
+            }
+            key="4"
+            neededItems={Array []}
+            setItems={[Function]}
+            setNeededItems={[Function]}
+          >
+            <article
+              className="Item"
+            >
+              <div
+                id="checkbox-item-container"
+              >
+                <img
+                  alt=""
+                  id="check-or-uncheck"
+                  onClick={[Function]}
+                  src={
+                    Object {
+                      "ReactComponent": Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "render": [Function],
+                      },
+                      "__esModule": true,
+                      "default": "unchecked.svg",
+                    }
+                  }
+                />
+                <h3
+                  id="item-name"
+                  onClick={[Function]}
+                >
+                  Feminine Products
+                </h3>
+              </div>
+            </article>
+          </Item>
+          <Item
+            item="Phone Charger (iphone)"
+            items={
+              Array [
+                "Diapers",
+                "Baby Wipes",
+                "Breastfeeding Supplies",
+                "Infant Formula",
+                "Feminine Products",
+                "Phone Charger (iphone)",
+                "Phone Charger (android)",
+                "add item",
+              ]
+            }
+            key="5"
+            neededItems={Array []}
+            setItems={[Function]}
+            setNeededItems={[Function]}
+          >
+            <article
+              className="Item"
+            >
+              <div
+                id="checkbox-item-container"
+              >
+                <img
+                  alt=""
+                  id="check-or-uncheck"
+                  onClick={[Function]}
+                  src={
+                    Object {
+                      "ReactComponent": Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "render": [Function],
+                      },
+                      "__esModule": true,
+                      "default": "unchecked.svg",
+                    }
+                  }
+                />
+                <h3
+                  id="item-name"
+                  onClick={[Function]}
+                >
+                  Phone Charger (iphone)
+                </h3>
+              </div>
+            </article>
+          </Item>
+          <Item
+            item="Phone Charger (android)"
+            items={
+              Array [
+                "Diapers",
+                "Baby Wipes",
+                "Breastfeeding Supplies",
+                "Infant Formula",
+                "Feminine Products",
+                "Phone Charger (iphone)",
+                "Phone Charger (android)",
+                "add item",
+              ]
+            }
+            key="6"
+            neededItems={Array []}
+            setItems={[Function]}
+            setNeededItems={[Function]}
+          >
+            <article
+              className="Item"
+            >
+              <div
+                id="checkbox-item-container"
+              >
+                <img
+                  alt=""
+                  id="check-or-uncheck"
+                  onClick={[Function]}
+                  src={
+                    Object {
+                      "ReactComponent": Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "render": [Function],
+                      },
+                      "__esModule": true,
+                      "default": "unchecked.svg",
+                    }
+                  }
+                />
+                <h3
+                  id="item-name"
+                  onClick={[Function]}
+                >
+                  Phone Charger (android)
+                </h3>
+              </div>
+            </article>
+          </Item>
+          <Item
+            item="add item"
+            items={
+              Array [
+                "Diapers",
+                "Baby Wipes",
+                "Breastfeeding Supplies",
+                "Infant Formula",
+                "Feminine Products",
+                "Phone Charger (iphone)",
+                "Phone Charger (android)",
+                "add item",
+              ]
+            }
+            key="7"
+            neededItems={Array []}
+            setItems={[Function]}
+            setNeededItems={[Function]}
+          >
+            <article
+              className="Item"
+            >
+              <div
+                id="add-item-container"
+              >
+                <input
+                  id="new-item"
+                  name="name"
+                  onChange={[Function]}
+                  placeholder="Add Item/Medication"
+                  type="text"
+                  value=""
+                />
+                <button
+                  id="submit-new-item"
+                  onClick={[Function]}
+                  type="submit"
+                >
+                  <img
+                    alt="plus symbol"
+                    id="plus-img"
+                    src={
+                      Object {
+                        "ReactComponent": Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "render": [Function],
+                        },
+                        "__esModule": true,
+                        "default": "plus-sign.svg",
+                      }
+                    }
+                  />
+                </button>
+              </div>
+            </article>
+          </Item>
+        </article>
+      </section>
+    </NeedsForm>
+    <EmergencyContactForm
+      emergencyName=""
+      emergencyPhone=""
+      emergencyRelationship=""
+      sendMessage={false}
+      setEmergencyName={[Function]}
+      setEmergencyPhone={[Function]}
+      setEmergencyRelationship={[Function]}
+      setSendMessage={[Function]}
+    >
+      <form
+        className="EmergencyContactForm"
+      >
+        <h1
+          id="emergency-contact-info-header"
+        >
+          Emergency Contact Information:
+        </h1>
+        <div
+          id="field"
+        >
+          <label
+            htmlFor="Full Name"
+            id="fullname-label"
+          >
+            Full Name:
+          </label>
+          <input
+            id="fullname"
+            name="name"
+            onChange={[Function]}
+            placeholder="Add Full Name"
+            type="text"
+            value=""
+          />
+        </div>
+        <div
+          id="field"
+        >
+          <label
+            htmlFor="phone"
+            id="phone-label"
+          >
+            Phone:
+          </label>
+          <input
+            id="phone"
+            name="phone"
+            onChange={[Function]}
+            placeholder="Add Phone Number"
+            type="text"
+            value=""
+          />
+        </div>
+        <div
+          id="field"
+        >
+          <label
+            htmlFor="relationship"
+            id="relationship-label"
+          >
+            Relationship:
+          </label>
+          <input
+            id="relationship"
+            name="relationship"
+            onChange={[Function]}
+            placeholder="Add Relationship"
+            type="text"
+            value=""
+          />
+        </div>
+        <div
+          id="make-public-or-private-container"
+        >
+          <h3
+            id="public-or-private-button-text"
+          >
+            By clicking the following button, I agree to allow a message to be sent to the emergency contact number listed above.
+          </h3>
+          <button
+            id="make-public-or-private-button"
+            onClick={[Function]}
+          >
+            Send Text to Contact
+          </button>
+        </div>
+      </form>
+    </EmergencyContactForm>
+    <hr />
+    <div
+      id="submit-form-button-container"
+    >
+      <h3
+        id="submit-form-text"
+      >
+        By clicking the "Submit Form" button below, I certify that all information in this form is true and correct to the best of my knowledge.
+      </h3>
+      <button
+        id="submit-form-button"
+        onClick={[Function]}
+      >
+        Submit Form
+      </button>
+    </div>
+  </section>
+</CheckInForm>
+`;

--- a/src/CheckOutForm/CheckOutForm.test.js
+++ b/src/CheckOutForm/CheckOutForm.test.js
@@ -1,0 +1,45 @@
+import React from "react";
+import { mount } from "enzyme";
+import CheckOutForm from "./CheckOutForm";
+import { UsersContext } from '../Contexts/UsersContext';
+import { configure } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+
+configure({ adapter: new Adapter() });
+
+describe("CheckOutForm", () => {
+  let wrapper;
+  let UsersContext;
+
+  beforeEach(() => {
+    UsersContext = {
+      reliefCenter: {
+        name: "Turing Relief Center",
+        addressPrint: "1331 17th St Denver CO 80202",
+        lat: "39.7508132",
+        lng: "-104.9967997",
+        phone: "5555555555",
+        website: "www.relief-center.com",
+        id: "1"
+      },
+      setreliefCenter: () => {}            
+    }
+    wrapper = mount(
+      <CheckOutForm/>,
+      { UsersContext }
+    );
+  });
+
+  it("should render without crashing", () => {
+    expect(wrapper.length).toEqual(1);
+  });
+
+  it("should match the snapshot", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("should mock context", () => {
+    wrapper.setContext({UsersContext})
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/CheckOutForm/__snapshots__/CheckOutForm.test.js.snap
+++ b/src/CheckOutForm/__snapshots__/CheckOutForm.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CheckOutForm should match the snapshot 1`] = `undefined`;
+
+exports[`CheckOutForm should match the snapshot 2`] = `undefined`;
+
+exports[`CheckOutForm should mock context 1`] = `undefined`;

--- a/src/Contexts/UsersContext.js
+++ b/src/Contexts/UsersContext.js
@@ -1,7 +1,3 @@
 import { createContext } from 'react';
 
 export const UsersContext = createContext([]);
-
-export const Provider = props => {
-  
-}

--- a/src/EmergencyContactForm/EmergencyContactForm.test.js
+++ b/src/EmergencyContactForm/EmergencyContactForm.test.js
@@ -1,0 +1,33 @@
+import React from "react";
+import { shallow } from "enzyme";
+import EmergencyContactForm from "./EmergencyContactForm";
+import { configure } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+
+configure({ adapter: new Adapter() });
+
+describe("EmergencyContactForm", () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(
+      <EmergencyContactForm
+        emergencyName=""
+        setEmergencyName={jest.fn()}
+        emergencyPhone=""
+        setEmergencyPhone={jest.fn()}
+        emergencyRelationship=""
+        setEmergencyRelationship={jest.fn()}
+        sendMessage={jest.fn()}
+      />
+    );
+  });
+
+  it("should render without crashing", () => {
+    expect(wrapper.length).toEqual(1);
+  });
+
+  it("should match the snapshot with three empty name, age, and phone inputs passed through", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/EmergencyContactForm/__snapshots__/EmergencyContactForm.test.js.snap
+++ b/src/EmergencyContactForm/__snapshots__/EmergencyContactForm.test.js.snap
@@ -1,0 +1,82 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EmergencyContactForm should match the snapshot with three empty name, age, and phone inputs passed through 1`] = `
+<form
+  className="EmergencyContactForm"
+>
+  <h1
+    id="emergency-contact-info-header"
+  >
+    Emergency Contact Information:
+  </h1>
+  <div
+    id="field"
+  >
+    <label
+      htmlFor="Full Name"
+      id="fullname-label"
+    >
+      Full Name:
+    </label>
+    <input
+      id="fullname"
+      name="name"
+      onChange={[Function]}
+      placeholder="Add Full Name"
+      type="text"
+      value=""
+    />
+  </div>
+  <div
+    id="field"
+  >
+    <label
+      htmlFor="phone"
+      id="phone-label"
+    >
+      Phone:
+    </label>
+    <input
+      id="phone"
+      name="phone"
+      onChange={[Function]}
+      placeholder="Add Phone Number"
+      type="text"
+      value=""
+    />
+  </div>
+  <div
+    id="field"
+  >
+    <label
+      htmlFor="relationship"
+      id="relationship-label"
+    >
+      Relationship:
+    </label>
+    <input
+      id="relationship"
+      name="relationship"
+      onChange={[Function]}
+      placeholder="Add Relationship"
+      type="text"
+      value=""
+    />
+  </div>
+  <div
+    id="make-public-or-private-container"
+  >
+    <h3
+      id="public-or-private-button-text"
+    >
+      By clicking the following button, I agree to allow a message to be sent to the emergency contact number listed above.
+    </h3>
+    <button
+      id="make-public-or-private-button"
+      onClick={[Function]}
+    >
+      Send Text to Contact
+    </button>
+  </div>
+</form>
+`;

--- a/src/Header/Header.test.js
+++ b/src/Header/Header.test.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Header } from './Header';
+import Header from './Header';
 
 
 describe('Header', () => {
   let wrapper;
 
   beforeEach(() => {
+    jest.resetModules()
     wrapper = shallow(<Header />)
   })
 

--- a/src/Item/Item.test.js
+++ b/src/Item/Item.test.js
@@ -1,0 +1,40 @@
+import React from "react";
+import { shallow } from "enzyme";
+import Item from "./Item";
+import { configure } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+
+configure({ adapter: new Adapter() });
+
+describe("Item", () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(
+      <Item
+        item=""
+        items={[
+          "Diapers",
+          "Baby Wipes",
+          "Breastfeeding Supplies",
+          "Infant Formula",
+          "Feminine Products",
+          "Phone Charger (iphone)",
+          "Phone Charger (android)",
+          "add item"
+          ]}
+        setItems={jest.fn()}
+        neededItems={[]}
+        setNeededItems={jest.fn()}
+      />
+    );
+  });
+
+  it("should render without crashing", () => {
+    expect(wrapper.length).toEqual(1);
+  });
+
+  it("should match the snapshot with three empty name, age, and phone inputs passed through", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/Item/__snapshots__/Item.test.js.snap
+++ b/src/Item/__snapshots__/Item.test.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Item should match the snapshot with three empty name, age, and phone inputs passed through 1`] = `
+<article
+  className="Item"
+>
+  <div
+    id="checkbox-item-container"
+  >
+    <img
+      alt=""
+      id="check-or-uncheck"
+      onClick={[Function]}
+      src={
+        Object {
+          "ReactComponent": Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "render": [Function],
+          },
+          "__esModule": true,
+          "default": "unchecked.svg",
+        }
+      }
+    />
+    <h3
+      id="item-name"
+      onClick={[Function]}
+    />
+  </div>
+</article>
+`;

--- a/src/LogInForm/LogInForm.test.js
+++ b/src/LogInForm/LogInForm.test.js
@@ -1,0 +1,37 @@
+import React from "react";
+import { mount } from "enzyme";
+import LogInForm from "./LogInForm";
+import { configure } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+
+configure({ adapter: new Adapter() });
+
+describe("LogInForm", () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mount(
+      <LogInForm
+      reliefCenter={{        
+        name: "Turing Relief Center",
+        addressPrint: "1331 17th St Denver CO 80202",
+        lat: "39.7508132",
+        lng: "-104.9967997",
+        phone: "5555555555",
+        website: "www.relief-center.com",
+        id: "1"
+      }}
+      selectCenter={jest.fn()} 
+      isCenterSelected={true}
+      />
+    );
+  });
+
+  it("should render without crashing", () => {
+    expect(wrapper.length).toEqual(1);
+  });
+
+  it("should match the snapshot", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/LogInForm/__snapshots__/LogInForm.test.js.snap
+++ b/src/LogInForm/__snapshots__/LogInForm.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LogInForm should match the snapshot 1`] = `undefined`;

--- a/src/Map/Map.test.js
+++ b/src/Map/Map.test.js
@@ -1,0 +1,27 @@
+import React from "react";
+import { shallow } from "enzyme";
+import Map from "./Map";
+import { configure } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+
+configure({ adapter: new Adapter() });
+
+describe("Map", () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(
+      <Map
+      selectCenter={jest.fn()}
+      />
+    );
+  });
+
+  it("should render without crashing", () => {
+    expect(wrapper.length).toEqual(1);
+  });
+
+  it("should match the snapshot", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/Map/__snapshots__/Map.test.js.snap
+++ b/src/Map/__snapshots__/Map.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Map should match the snapshot 1`] = `undefined`;

--- a/src/NeedsForm/NeedsForm.test.js
+++ b/src/NeedsForm/NeedsForm.test.js
@@ -1,0 +1,39 @@
+import React from "react";
+import { mount } from "enzyme";
+import NeedsForm from "./NeedsForm";
+import { configure } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+
+configure({ adapter: new Adapter() });
+
+describe("NeedsForm", () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mount(
+        <NeedsForm
+        items={[
+        "Diapers",
+        "Baby Wipes",
+        "Breastfeeding Supplies",
+        "Infant Formula",
+        "Feminine Products",
+        "Phone Charger (iphone)",
+        "Phone Charger (android)",
+        "add item"
+        ]}
+        setItems={jest.fn()}
+        neededItems={[]}
+        setNeededItems={jest.fn()}
+      />
+    );
+  });
+
+  it("should render without crashing", () => {
+    expect(wrapper.length).toEqual(1);
+  });
+
+  it("should match the snapshot", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/NeedsForm/__snapshots__/NeedsForm.test.js.snap
+++ b/src/NeedsForm/__snapshots__/NeedsForm.test.js.snap
@@ -1,0 +1,434 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NeedsForm should match the snapshot 1`] = `
+<NeedsForm
+  items={
+    Array [
+      "Diapers",
+      "Baby Wipes",
+      "Breastfeeding Supplies",
+      "Infant Formula",
+      "Feminine Products",
+      "Phone Charger (iphone)",
+      "Phone Charger (android)",
+      "add item",
+    ]
+  }
+  neededItems={Array []}
+  setItems={[MockFunction]}
+  setNeededItems={[MockFunction]}
+>
+  <section
+    className="NeedsForm"
+  >
+    <h1
+      id="necessities-header"
+    >
+      Necessities:
+    </h1>
+    <article
+      id="items-container"
+    >
+      <Item
+        item="Diapers"
+        items={
+          Array [
+            "Diapers",
+            "Baby Wipes",
+            "Breastfeeding Supplies",
+            "Infant Formula",
+            "Feminine Products",
+            "Phone Charger (iphone)",
+            "Phone Charger (android)",
+            "add item",
+          ]
+        }
+        key="0"
+        neededItems={Array []}
+        setItems={[MockFunction]}
+        setNeededItems={[MockFunction]}
+      >
+        <article
+          className="Item"
+        >
+          <div
+            id="checkbox-item-container"
+          >
+            <img
+              alt=""
+              id="check-or-uncheck"
+              onClick={[Function]}
+              src={
+                Object {
+                  "ReactComponent": Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "render": [Function],
+                  },
+                  "__esModule": true,
+                  "default": "unchecked.svg",
+                }
+              }
+            />
+            <h3
+              id="item-name"
+              onClick={[Function]}
+            >
+              Diapers
+            </h3>
+          </div>
+        </article>
+      </Item>
+      <Item
+        item="Baby Wipes"
+        items={
+          Array [
+            "Diapers",
+            "Baby Wipes",
+            "Breastfeeding Supplies",
+            "Infant Formula",
+            "Feminine Products",
+            "Phone Charger (iphone)",
+            "Phone Charger (android)",
+            "add item",
+          ]
+        }
+        key="1"
+        neededItems={Array []}
+        setItems={[MockFunction]}
+        setNeededItems={[MockFunction]}
+      >
+        <article
+          className="Item"
+        >
+          <div
+            id="checkbox-item-container"
+          >
+            <img
+              alt=""
+              id="check-or-uncheck"
+              onClick={[Function]}
+              src={
+                Object {
+                  "ReactComponent": Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "render": [Function],
+                  },
+                  "__esModule": true,
+                  "default": "unchecked.svg",
+                }
+              }
+            />
+            <h3
+              id="item-name"
+              onClick={[Function]}
+            >
+              Baby Wipes
+            </h3>
+          </div>
+        </article>
+      </Item>
+      <Item
+        item="Breastfeeding Supplies"
+        items={
+          Array [
+            "Diapers",
+            "Baby Wipes",
+            "Breastfeeding Supplies",
+            "Infant Formula",
+            "Feminine Products",
+            "Phone Charger (iphone)",
+            "Phone Charger (android)",
+            "add item",
+          ]
+        }
+        key="2"
+        neededItems={Array []}
+        setItems={[MockFunction]}
+        setNeededItems={[MockFunction]}
+      >
+        <article
+          className="Item"
+        >
+          <div
+            id="checkbox-item-container"
+          >
+            <img
+              alt=""
+              id="check-or-uncheck"
+              onClick={[Function]}
+              src={
+                Object {
+                  "ReactComponent": Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "render": [Function],
+                  },
+                  "__esModule": true,
+                  "default": "unchecked.svg",
+                }
+              }
+            />
+            <h3
+              id="item-name"
+              onClick={[Function]}
+            >
+              Breastfeeding Supplies
+            </h3>
+          </div>
+        </article>
+      </Item>
+      <Item
+        item="Infant Formula"
+        items={
+          Array [
+            "Diapers",
+            "Baby Wipes",
+            "Breastfeeding Supplies",
+            "Infant Formula",
+            "Feminine Products",
+            "Phone Charger (iphone)",
+            "Phone Charger (android)",
+            "add item",
+          ]
+        }
+        key="3"
+        neededItems={Array []}
+        setItems={[MockFunction]}
+        setNeededItems={[MockFunction]}
+      >
+        <article
+          className="Item"
+        >
+          <div
+            id="checkbox-item-container"
+          >
+            <img
+              alt=""
+              id="check-or-uncheck"
+              onClick={[Function]}
+              src={
+                Object {
+                  "ReactComponent": Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "render": [Function],
+                  },
+                  "__esModule": true,
+                  "default": "unchecked.svg",
+                }
+              }
+            />
+            <h3
+              id="item-name"
+              onClick={[Function]}
+            >
+              Infant Formula
+            </h3>
+          </div>
+        </article>
+      </Item>
+      <Item
+        item="Feminine Products"
+        items={
+          Array [
+            "Diapers",
+            "Baby Wipes",
+            "Breastfeeding Supplies",
+            "Infant Formula",
+            "Feminine Products",
+            "Phone Charger (iphone)",
+            "Phone Charger (android)",
+            "add item",
+          ]
+        }
+        key="4"
+        neededItems={Array []}
+        setItems={[MockFunction]}
+        setNeededItems={[MockFunction]}
+      >
+        <article
+          className="Item"
+        >
+          <div
+            id="checkbox-item-container"
+          >
+            <img
+              alt=""
+              id="check-or-uncheck"
+              onClick={[Function]}
+              src={
+                Object {
+                  "ReactComponent": Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "render": [Function],
+                  },
+                  "__esModule": true,
+                  "default": "unchecked.svg",
+                }
+              }
+            />
+            <h3
+              id="item-name"
+              onClick={[Function]}
+            >
+              Feminine Products
+            </h3>
+          </div>
+        </article>
+      </Item>
+      <Item
+        item="Phone Charger (iphone)"
+        items={
+          Array [
+            "Diapers",
+            "Baby Wipes",
+            "Breastfeeding Supplies",
+            "Infant Formula",
+            "Feminine Products",
+            "Phone Charger (iphone)",
+            "Phone Charger (android)",
+            "add item",
+          ]
+        }
+        key="5"
+        neededItems={Array []}
+        setItems={[MockFunction]}
+        setNeededItems={[MockFunction]}
+      >
+        <article
+          className="Item"
+        >
+          <div
+            id="checkbox-item-container"
+          >
+            <img
+              alt=""
+              id="check-or-uncheck"
+              onClick={[Function]}
+              src={
+                Object {
+                  "ReactComponent": Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "render": [Function],
+                  },
+                  "__esModule": true,
+                  "default": "unchecked.svg",
+                }
+              }
+            />
+            <h3
+              id="item-name"
+              onClick={[Function]}
+            >
+              Phone Charger (iphone)
+            </h3>
+          </div>
+        </article>
+      </Item>
+      <Item
+        item="Phone Charger (android)"
+        items={
+          Array [
+            "Diapers",
+            "Baby Wipes",
+            "Breastfeeding Supplies",
+            "Infant Formula",
+            "Feminine Products",
+            "Phone Charger (iphone)",
+            "Phone Charger (android)",
+            "add item",
+          ]
+        }
+        key="6"
+        neededItems={Array []}
+        setItems={[MockFunction]}
+        setNeededItems={[MockFunction]}
+      >
+        <article
+          className="Item"
+        >
+          <div
+            id="checkbox-item-container"
+          >
+            <img
+              alt=""
+              id="check-or-uncheck"
+              onClick={[Function]}
+              src={
+                Object {
+                  "ReactComponent": Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "render": [Function],
+                  },
+                  "__esModule": true,
+                  "default": "unchecked.svg",
+                }
+              }
+            />
+            <h3
+              id="item-name"
+              onClick={[Function]}
+            >
+              Phone Charger (android)
+            </h3>
+          </div>
+        </article>
+      </Item>
+      <Item
+        item="add item"
+        items={
+          Array [
+            "Diapers",
+            "Baby Wipes",
+            "Breastfeeding Supplies",
+            "Infant Formula",
+            "Feminine Products",
+            "Phone Charger (iphone)",
+            "Phone Charger (android)",
+            "add item",
+          ]
+        }
+        key="7"
+        neededItems={Array []}
+        setItems={[MockFunction]}
+        setNeededItems={[MockFunction]}
+      >
+        <article
+          className="Item"
+        >
+          <div
+            id="add-item-container"
+          >
+            <input
+              id="new-item"
+              name="name"
+              onChange={[Function]}
+              placeholder="Add Item/Medication"
+              type="text"
+              value=""
+            />
+            <button
+              id="submit-new-item"
+              onClick={[Function]}
+              type="submit"
+            >
+              <img
+                alt="plus symbol"
+                id="plus-img"
+                src={
+                  Object {
+                    "ReactComponent": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "render": [Function],
+                    },
+                    "__esModule": true,
+                    "default": "plus-sign.svg",
+                  }
+                }
+              />
+            </button>
+          </div>
+        </article>
+      </Item>
+    </article>
+  </section>
+</NeedsForm>
+`;

--- a/src/SuppliesForm/SuppliesForm.js
+++ b/src/SuppliesForm/SuppliesForm.js
@@ -2,6 +2,7 @@ import React, { useContext, useState } from 'react';
 import { patchItem, addItem } from '../apiCalls/apiCalls';
 import { CurrentCenterContext } from '../Contexts/CurrentCenterContext';
 import { ItemsContext } from '../Contexts/ItemsContext';
+import PropTypes from 'prop-types';
 import './SuppliesForm.css';
 
 const SuppliesForm = () => {
@@ -162,3 +163,10 @@ const SuppliesForm = () => {
 }
 
 export default SuppliesForm
+
+SuppliesForm.contextTypes = {
+  reliefCenter: PropTypes.object,
+  setreliefCenter: PropTypes.func,
+  currentItems: PropTypes.arrayOf(PropTypes.object),
+  setCurrentItems: PropTypes.func
+};

--- a/src/SuppliesForm/SuppliesForm.test.js
+++ b/src/SuppliesForm/SuppliesForm.test.js
@@ -1,0 +1,59 @@
+import React from "react";
+import { mount } from "enzyme";
+import SuppliesForm from "./SuppliesForm";
+import { UsersContext } from '../Contexts/UsersContext';
+import { ItemsContext } from '../Contexts/ItemsContext';
+import { configure } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+
+configure({ adapter: new Adapter() });
+
+describe("SuppliesForm", () => {
+  let wrapper;
+  let UsersContext;
+  let ItemsContext;
+
+  beforeEach(() => {
+      UsersContext = {
+        reliefCenter: {
+          name: "Turing Relief Center",
+          addressPrint: "1331 17th St Denver CO 80202",
+          lat: "39.7508132",
+          lng: "-104.9967997",
+          phone: "5555555555",
+          website: "www.relief-center.com",
+          id: "1"
+        },
+        setreliefCenter: () => {}            
+      }
+      ItemsContext = {
+        currentItems: [
+          {id: "1", name: "Diapers", quantity: 10},
+          {id: "2", name: "Food", quantity: 10},
+          {id: "3", name: "Water", quantity: 11},
+          {id: "4", name: "Soap", quantity: 7},
+          {id: "5", name: "Toothpaste", quantity: 0}
+        ],
+        setCurrentItems: () => {}            
+      }
+      wrapper = mount(
+        <SuppliesForm/>,
+        { UsersContext },
+        { ItemsContext }
+      );
+    });
+
+  it("should render without crashing", () => {
+    expect(wrapper.length).toEqual(1);
+  });
+
+  it("should match the snapshot", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("should mock context", () => {
+    wrapper.setContext({ UsersContext })
+    wrapper.setContext({ ItemsContext })
+    expect(wrapper).toMatchSnapshot();
+  });
+})

--- a/src/SuppliesForm/__snapshots__/SuppliesForm.test.js.snap
+++ b/src/SuppliesForm/__snapshots__/SuppliesForm.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SuppliesForm should match the snapshot 1`] = `undefined`;


### PR DESCRIPTION
#### What’s this PR do?
This PR adds preliminary snapshot tests to all component files. Also, I ran ```npm install prop-Types -S``` for our testing suite, as we were erroring out without them. Added PropTypes to SuppliesForm to see if it aided in passing the snapshot. 
#### Where should the reviewer start?
The review should start by running ```npm test```
#### How should this be manually tested?
See above
#### Any background context you want to provide?
While we have 22 tests passing, we have 10 failing. I believe this is an issue with mocking context functionality.
#### Screenshots (if appropriate)

<img width="748" alt="Screen Shot 2019-10-30 at 12 15 39 AM" src="https://user-images.githubusercontent.com/11339301/67833739-20505d00-faab-11e9-959b-6e4e654aad7c.png">

#### Questions:
Any ideas on how to conquer mocking and/or applying context?